### PR TITLE
Exchange node-sass with sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "husky": "7.0.4",
     "jest": "27.5.1",
     "lint-staged": "12.3.4",
-    "node-sass": "6.0.1",
+    "sass": "1.49.8",
     "ts-jest": "27.1.3",
     "typescript": "4.5.5"
   },


### PR DESCRIPTION
node-sass is deprecated and it's recommended to change it out with dart-sass(sass)